### PR TITLE
FIx handling of Confluent schema registry (#82)

### DIFF
--- a/forward_engineering/config.json
+++ b/forward_engineering/config.json
@@ -10,7 +10,8 @@
     {
       "name": "Avro Schema",
       "keyword": "avroSchema",
-      "disableApplyScriptToInstance": true
+      "disableApplyScriptToInstance": true,
+      "cliOnly": true
     },
     {
       "name": "Schema Registry",
@@ -22,7 +23,8 @@
     {
       "name": "Azure Schema Registry",
       "keyword": "azureSchemaRegistry",
-      "isApplicationHandler": true
+      "isApplicationHandler": true,
+      "cliOnly": true
     },
     {
       "name": "Confluent API Schema",
@@ -33,12 +35,14 @@
           "value": "txt",
           "label": "txt"
         }
-      ]
+      ],
+      "cliOnly": true
     },
     {
       "name": "Pulsar Schema Registry",
       "keyword": "pulsarSchemaRegistry",
-      "isApplicationHandler": true
+      "isApplicationHandler": true,
+      "cliOnly": true
     }
   ],
   "additionalOptions": [
@@ -57,19 +61,22 @@
           "name": "Confluent API Schema",
           "keyword": "confluentSchemaRegistry",
           "mode": "json",
-          "isApplicationHandler": true
+          "isApplicationHandler": true,
+          "cliOnly": true
         },
         {
           "name": "Azure Schema Registry",
           "keyword": "azureSchemaRegistry",
           "mode": "json",
-          "isApplicationHandler": true
+          "isApplicationHandler": true,
+          "cliOnly": true
         },
         {
           "name": "Pulsar Schema Registry",
           "keyword": "pulsarSchemaRegistry",
           "mode": "json",
-          "isApplicationHandler": true
+          "isApplicationHandler": true,
+          "cliOnly": true
         }
       ]
     }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "versionDate": "2022-12-02",
     "author": "hackolade",
     "engines": {
-        "hackolade": "5.2.13",
+        "hackolade": "6.7.2",
         "hackoladePlugin": "1.0.0"
     },
     "contributes": {

--- a/properties_pane/container_level/containerLevelConfig.json
+++ b/properties_pane/container_level/containerLevelConfig.json
@@ -136,7 +136,12 @@ making sure that you maintain a proper JSON format.
 			{
 				"propertyName": "Schema group name",
 				"propertyKeyword": "schemaGroupName",
-				"propertyType": "text"
+				"propertyType": "text",
+				"dependency": {
+					"level": "model",
+					"key": "schemaRegistryType",
+					"value": "Azure Schema Registry"
+				}
 			},
 			{
 				"propertyName": "Description",

--- a/properties_pane/entity_level/entityLevelConfig.json
+++ b/properties_pane/entity_level/entityLevelConfig.json
@@ -141,7 +141,7 @@ making sure that you maintain a proper JSON format.
 				"propertyType": "selecthashed"
 			},
 			{
-				"propertyName": "Confluent schema type",
+				"propertyName": "Schema type",
 				"propertyKeyword": "schemaType",
 				"propertyTooltip": "Select from list of options",
 				"propertyType": "select",
@@ -149,23 +149,91 @@ making sure that you maintain a proper JSON format.
 					"",
 					"key",
 					"value"
-				]
+				],
+				"dependency": {
+					"level": "model",
+					"key": "schemaRegistryType",
+					"value": "Confluent Schema Registry"
+				}
+			},
+			{
+				"propertyName": "Subject Name Strategy",
+				"propertyKeyword": "schemaNameStrategy",
+				"propertyTooltip": "Select from list of options",
+				"propertyType": "select",
+				"validation": {
+					"required": true
+				},
+				"options": [
+					"",
+					"TopicNameStrategy",
+					"RecordNameStrategy",
+					"TopicRecordNameStrategy"
+				],
+				"dependency": {
+					"level": "model",
+					"key": "schemaRegistryType",
+					"value": "Confluent Schema Registry"
+				}
+			},
+			{
+				"propertyName": "Topic",
+				"propertyKeyword": "schemaTopic",
+				"shouldValidate": false,
+				"propertyTooltip": "",
+				"propertyType": "text",
+				"dependency": {
+					"type": "and", 
+					"values": [
+						{
+						"level": "model",
+						"key": "schemaRegistryType",
+						"value": "Confluent Schema Registry"
+						}, [{
+							"key": "schemaNameStrategy",
+							"value": "TopicNameStrategy"
+						}, {
+							"key": "schemaNameStrategy",
+							"value": "TopicRecordNameStrategy"
+						}]
+					]
+				}
+			},
+			{
+				"propertyName": "Pulsar topic name",
+				"propertyKeyword": "pulsarTopicName",
+				"propertyType": "text",
+				"dependency": {
+					"level": "model",
+					"key": "schemaRegistryType",
+					"value": "Pulsar Schema Registry"
+				}
+			},
+			{
+				"propertyName": "Is non-persistent Pulsar topic",
+				"propertyKeyword": "isNonPersistentTopic",
+				"propertyType": "checkbox",
+				"template": "boolean",
+				"dependency": {
+					"level": "model",
+					"key": "schemaRegistryType",
+					"value": "Pulsar Schema Registry"
+				}
+			},
+			{
+				"propertyName": "Subject",
+				"propertyKeyword": "confluentSubjectName",
+				"propertyType": "text",
+				"dependency": {
+					"level": "model",
+					"key": "schemaRegistryType",
+					"value": "Confluent Schema Registry"
+				}
 			},
 			{
 				"propertyName": "Additional properties",
 				"propertyKeyword": "additionalProperties",
 				"propertyTooltip": "Description",
-				"propertyType": "checkbox",
-				"template": "boolean"
-			},
-			{
-				"propertyName": "Pulsar topic name",
-				"propertyKeyword": "pulsarTopicName",
-				"propertyType": "text"
-			},
-			{
-				"propertyName": "Is non-persistent Pulsar topic",
-				"propertyKeyword": "isNonPersistentTopic",
 				"propertyType": "checkbox",
 				"template": "boolean"
 			},

--- a/properties_pane/model_level/modelLevelConfig.json
+++ b/properties_pane/model_level/modelLevelConfig.json
@@ -140,27 +140,33 @@ making sure that you maintain a proper JSON format.
 				"disabledOption": true
 			},
 			{
-				"propertyName": "Subject Name Strategy",
-				"propertyKeyword": "schemaNameStrategy",
+				"propertyName": "Schema registry",
+				"propertyKeyword": "schemaRegistryType",
 				"propertyTooltip": "Select from list of options",
 				"propertyType": "select",
 				"options": [
 					"",
-					"TopicNameStrategy",
-					"RecordNameStrategy",
-					"TopicRecordNameStrategy"
+					"Confluent Schema Registry",
+					"Azure Schema Registry",
+					"Pulsar Schema Registry"
       			]
 			},
 			{
-				"propertyName": "Topic",
-				"propertyKeyword": "schemaTopic",
+				"propertyName": "Schema registry URL",
+				"propertyKeyword": "schemaRegistryUrl",
 				"shouldValidate": false,
 				"propertyTooltip": "",
 				"propertyType": "text",
-				"dependency": {
-					"key": "schemaNameStrategy",
-					"value": "TopicRecordNameStrategy"
-				}
+				"dependency": [{
+					"key": "schemaRegistryType",
+					"value": "Confluent Schema Registry"
+				},{
+					"key": "schemaRegistryType",
+					"value": "Azure Schema Registry"
+				},{
+					"key": "schemaRegistryType",
+					"value": "Pulsar Schema Registry"
+				}]
 			},
 			{
 				"propertyName": "Comments",

--- a/reverse_engineering/api.js
+++ b/reverse_engineering/api.js
@@ -16,18 +16,12 @@ const reFromFile = async (data, logger, callback, app) => {
 		const avroSchema = await openAvroFile(filePath);
 		const jsonSchemas = convertToJsonSchemas(avroSchema);
 
-		if (jsonSchemas.length === 1) {
-			const { schemaGroupName, namespace } = _.first(getSchemasData(avroSchema));
+		const { schemaRegistryType, schemaRegistryUrl } = _.first(getSchemasData(avroSchema));
 
-			return callback(null, {
-				jsonSchema: JSON.stringify(_.first(jsonSchemas)),
-				extension: getExtension(filePath),
-				containerName: namespace,
-				containerAdditionalData: { schemaGroupName }
-			});
-		}
-
-		return callback(null, getPackages(avroSchema, jsonSchemas), {}, [],  'multipleSchema');
+		return callback(null, getPackages(avroSchema, jsonSchemas), {
+			schemaRegistryType,
+			schemaRegistryUrl,
+		}, [],  'multipleSchema');
 	} catch (err) {
 		const errorData = handleErrorObject(err);
 		logger.log('error', errorData, 'Parsing Avro Schema Error');
@@ -59,20 +53,29 @@ const adaptJsonSchema = (data, logger, callback, app) => {
 const getPackages = (avroSchema, jsonSchemas) => {
 	const schemasData = getSchemasData(avroSchema);
 
-	return jsonSchemas.map((jsonSchema, index) => ({
-		objectNames: {
-			collectionName: jsonSchema.title,
-		},
-		doc: {
-			dbName: schemasData[index]?.namespace || '',
-			collectionName: jsonSchema.title,
-			bucketInfo: {
-				name: schemasData[index]?.namespace || '',
-				schemaGroupName: schemasData[index]?.schemaGroupName || ''
+	return jsonSchemas.map((jsonSchema, index) => {
+		const { namespace, schemaType, schemaGroupName, confluentSubjectName, schemaTopic } = schemasData[index] || {};
+
+		return {
+			objectNames: {
+				collectionName: jsonSchema.title,
 			},
-		},
-		jsonSchema: JSON.stringify(jsonSchema),
-	}));
+			doc: {
+				dbName: namespace || '',
+				collectionName: jsonSchema.title,
+				bucketInfo: {
+					name: namespace || '',
+				},
+			},
+			jsonSchema: JSON.stringify({
+				...jsonSchema,
+				schemaType: schemaType,
+				schemaTopic: schemaTopic,
+				schemaGroupName: schemaGroupName,
+				confluentSubjectName: confluentSubjectName,
+			}),
+		};
+	});
 };
 
 const getSchemasData = avroSchema => {
@@ -81,6 +84,11 @@ const getSchemasData = avroSchema => {
 	return avroSchema.map(schema => ({
 		namespace: getNamespace(schema) || '',
 		schemaGroupName: schema.schemaGroupName,
+		schemaRegistryType: schema.schemaRegistryType,
+		schemaRegistryUrl: schema.schemaRegistryUrl,
+		confluentSubjectName: schema.confluentSubjectName,
+		schemaTopic: schema.schemaTopic,
+		schemaType: schema.schemaType,
 	}));
 }
 

--- a/shared/constants.js
+++ b/shared/constants.js
@@ -6,6 +6,12 @@ const META_VALUES_KEY_MAP = {
 	'java-key-class': 'metaValueKeyClass'
 };
 
+const SCHEMA_REGISTRIES_KEYS = {
+	'Confluent Schema Registry': 'CONFLUENT_SCHEMA_REGISTRY',
+	'Azure Schema Registry': 'AZURE_SCHEMA_REGISTRY',
+	'Pulsar Schema Registry': 'PULSAR_SCHEMA_REGISTRY',
+};
+
 const SCRIPT_TYPES = {
 	CONFLUENT_SCHEMA_REGISTRY: 'confluentSchemaRegistry',
 	AZURE_SCHEMA_REGISTRY: 'azureSchemaRegistry',
@@ -34,6 +40,7 @@ const AVRO_TYPES = [
 module.exports = {
 	META_VALUES_KEY_MAP,
 	SCRIPT_TYPES,
+	SCHEMA_REGISTRIES_KEYS,
 	GENERAL_ATTRIBUTES,
 	AVRO_TYPES,
 };


### PR DESCRIPTION
* Fix: separate confluent subject name from azure schema group name

* Fix: add confluent subject name property to bucket level

* Confluent RE: fixed getting subject name

* Schema registries: move schema registries related properties to model-level. Update logic for Conluent

* Confluent schema registry: fix default script type on model level

* Confluent: hide schema registries options from FE

* FE: Added Confluent subject name property handling

* fix indentation

* FE: fix duplicated dash for topic name strategy

* RE from Confluent: omit empty schema registry metadata values

* FE: Fix redundant space in Azure FE script